### PR TITLE
keep the data field when storing and loading the schema

### DIFF
--- a/src/downloadSchema.js
+++ b/src/downloadSchema.js
@@ -37,8 +37,8 @@ export default async function downloadSchema(url, outputPath, additionalHeaders)
     throw new ToolError(`Errors in introspection query result: ${result.errors}`);
   }
 
-  const schemaData = result.data;
-  if (!schemaData) {
+  const schemaData = result;
+  if (!schemaData.data) {
     throw new ToolError(`No introspection query result data found, server responded with: ${JSON.stringify(result)}`);
   }
 

--- a/src/loading.js
+++ b/src/loading.js
@@ -17,11 +17,10 @@ export function loadSchema(schemaPath) {
   }
   const schemaData = require(schemaPath);
 
-  if (!schemaData.__schema) {
+  if (!schemaData.data && !schemaData.__schema) {
     throw new ToolError('GraphQL schema file should contain a valid GraphQL introspection query result');
   }
-
-  return buildClientSchema(schemaData);
+  return buildClientSchema((schemaData.data) ? schemaData.data : schemaData);
 }
 
 export function loadAndMergeQueryDocuments(inputPaths) {


### PR DESCRIPTION
Simply, modifies downloadSchema to keep the `data` field when storing the schema file to disk. An error is now thrown if `data` isn't the top-level field in the response.

As far as loading the schema for code-generation goes, an error is thrown when neither `data` nor `schema` exist as the top-level field. The reasoning is so as not break the old code-gen behaviour but I can modify that to only check for `data`.

Closes #8.