### PR TITLE
[TypeScript] Fixed bug with camelCased propertyName

### DIFF
--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -172,10 +172,8 @@ export function propertiesFromFields(context, fields, forceNullable) {
 export function propertyFromField(context, field, forceNullable) {
   const { name: fieldName, type: fieldType, description, fragmentSpreads, inlineFragments } = field;
 
-  const propertyName = camelCase(fieldName);
-
+  const propertyName = fieldName;
   let property = { fieldName, fieldType, propertyName, description };
-
   const namedType = getNamedType(fieldType);
 
   if (isCompositeType(namedType)) {


### PR DESCRIPTION
@rricard 

Can't add quick unit tests because the star wars schema does not have non-camelcased properties that I can add quick test for. 
Verified it against the GitHunt schema and it works.

https://github.com/apollostack/apollo-codegen/pull/5