### PR TITLE
Fix variables map to use field name instead of camel cased name / Use Double for GraphQLFloat.

### DIFF
--- a/src/swift/codeGeneration.js
+++ b/src/swift/codeGeneration.js
@@ -111,7 +111,7 @@ export function classDeclarationForOperation(
         const propertyName = camelCase(name);
         const typeName = typeNameFromGraphQLType(generator.context, type);
         const isOptional = !(type instanceof GraphQLNonNull || type.ofType instanceof GraphQLNonNull);
-        return { propertyName, type, typeName, isOptional };
+        return { name, propertyName, type, typeName, isOptional };
       });
       generator.printNewlineIfNeeded();
       propertyDeclarations(generator, properties);
@@ -122,7 +122,7 @@ export function classDeclarationForOperation(
       generator.withinBlock(() => {
         generator.printOnNewline(wrap(
           `return [`,
-          join(properties.map(({ propertyName }) => `"${propertyName}": ${propertyName}`), ', '),
+          join(properties.map(({ name, propertyName }) => `"${name}": ${propertyName}`), ', '),
           `]`
         ));
       });

--- a/src/swift/types.js
+++ b/src/swift/types.js
@@ -22,7 +22,7 @@ import {
 const builtInScalarMap = {
   [GraphQLString.name]: 'String',
   [GraphQLInt.name]: 'Int',
-  [GraphQLFloat.name]: 'Float',
+  [GraphQLFloat.name]: 'Double',
   [GraphQLBoolean.name]: 'Bool',
   [GraphQLID.name]: 'GraphQLID',
 }

--- a/test/swift/types.js
+++ b/test/swift/types.js
@@ -50,8 +50,8 @@ describe('Swift code generation: Types', function() {
       expect(typeNameFromGraphQLType({}, GraphQLInt)).to.equal('Int?');
     });
 
-    it('should return Float? for GraphQLFloat', function() {
-      expect(typeNameFromGraphQLType({}, GraphQLFloat)).to.equal('Float?');
+    it('should return Double? for GraphQLFloat', function() {
+      expect(typeNameFromGraphQLType({}, GraphQLFloat)).to.equal('Double?');
     });
 
     it('should return Bool? for GraphQLBoolean', function() {


### PR DESCRIPTION
Hi,

I've found that if the GraphQL field names are not camel cased then the variables mapping is wrong:

Current code (wrong):

```
  public var variables: GraphQLMap? {
    return ["userId": userId]
  }
```

Fixed code (correct):

```
  public var variables: GraphQLMap? {
    return ["user_id": userId]
  }
```

This patch fixes the issue.

Also, Javascript floats are double precision, so I believe the correct mapping to Swift should be a Double instead of a Float. An update to the mapping fixes this.
