### PR TITLE
Disable tslint in generated file

### DIFF
--- a/src/typescript/codeGeneration.js
+++ b/src/typescript/codeGeneration.js
@@ -37,6 +37,8 @@ export function generateSource(context) {
   const generator = new CodeGenerator(context);
 
   generator.printOnNewline('//  This file was automatically generated and should not be edited.');
+  generator.printOnNewline('/* tslint:disable */');
+
   typeDeclarationForGraphQLType(context.typesUsed.forEach(type =>
     typeDeclarationForGraphQLType(generator, type)
   ));
@@ -47,6 +49,9 @@ export function generateSource(context) {
   Object.values(context.fragments).forEach(operation =>
     interfaceDeclarationForFragment(generator, operation)
   );
+
+  generator.printOnNewline('/* tslint:enable */');
+  generator.printOnNewline();
 
   return generator.output;
 }

--- a/test/typescript/codeGeneration.js
+++ b/test/typescript/codeGeneration.js
@@ -60,12 +60,15 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         export interface HeroNameQuery {
           hero: {
             name: string,
           } | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -82,6 +85,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         // The episodes in the Star Wars trilogy
         export type Episode =
@@ -99,6 +103,8 @@ describe('TypeScript code generation', function() {
             name: string,
           } | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -118,6 +124,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         // The episodes in the Star Wars trilogy
         export type Episode =
@@ -138,6 +145,8 @@ describe('TypeScript code generation', function() {
             } > | null,
           } | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -161,6 +170,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         export interface HeroAndFriendsNamesQuery {
           hero: HeroFriendsFragment & {
@@ -173,6 +183,8 @@ describe('TypeScript code generation', function() {
             name: string,
           } > | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -199,6 +211,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         export interface HeroAndDetailsQuery {
           hero: HeroDetailsFragment & {
@@ -210,6 +223,8 @@ describe('TypeScript code generation', function() {
           primaryFunction: string | null;
           height: number | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -227,6 +242,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
 
         // The episodes in the Star Wars trilogy
         export type Episode =
@@ -261,6 +277,8 @@ describe('TypeScript code generation', function() {
             commentary: string | null,
           } | null;
         }
+        /* tslint:enable */
+
       `);
     });
 
@@ -284,6 +302,7 @@ describe('TypeScript code generation', function() {
 
       expect(source).to.include(stripIndent`
         //  This file was automatically generated and should not be edited.
+        /* tslint:disable */
         
         // The episodes in the Star Wars trilogy
         export type Episode =
@@ -306,6 +325,8 @@ describe('TypeScript code generation', function() {
         export interface FriendFragment {
           name: string;
         }
+        /* tslint:enable */
+
       `);
     });
   });


### PR DESCRIPTION
Excluding files in TSLint via `tslint.json` is not supported and when using this tool TSLint may fail because of incompatibility.
Auto-generated code shouldn't pass thru TSLint so this change adds `tslint-disable` statement to the generated file and makes it safe to use with any TSLint configuration.