### PR TITLE
skip validation of NoUnusedFragments and NoUnusedVariables

### DIFF
--- a/src/validation.js
+++ b/src/validation.js
@@ -6,9 +6,11 @@ import {
 
 import { ToolError, logError } from './errors'
 
-export function validateQueryDocument(schema, document) {
-  const rules = [NoAnonymousQueries, NoExplicitTypename, NoTypenameAlias].concat(specifiedRules);
+// `specifiedRules` validates queries but codegen may run on just fragments of an actual query to the resolver.
+const baseRules = specifiedRules.filter(r => !r.name.startsWith('NoUnused'));
+const rules = [NoAnonymousQueries, NoExplicitTypename, NoTypenameAlias].concat(baseRules);
 
+export function validateQueryDocument(schema, document) {
   const validationErrors = validate(schema, document, rules);
   if (validationErrors && validationErrors.length > 0) {
     for (const error of validationErrors) {

--- a/test/starwars/HeroDetailsFragment.graphql
+++ b/test/starwars/HeroDetailsFragment.graphql
@@ -1,0 +1,9 @@
+fragment HeroDetails on Character {
+  name
+  ... on Droid {
+    primaryFunction
+  }
+  ... on Human {
+    height
+  }
+}

--- a/test/validation.js
+++ b/test/validation.js
@@ -42,4 +42,14 @@ describe('Validation', () => {
       'Validation of GraphQL query document failed'
     );
   });
+
+  it.only(`should not throw an error for NoUnusedFragments violation`, () => {
+    const inputPaths = [path.join(__dirname, './starwars/HeroDetailsFragment.graphql')];
+    const document = loadAndMergeQueryDocuments(inputPaths);
+
+    assert.doesNotThrow(
+      () => validateQueryDocument(schema, document),
+      'Validation of GraphQL query document failed'
+    );
+  });
 });


### PR DESCRIPTION
specifiedRules` validates queries but codegen may run on just fragments of an actual query to the resolver.