### PR TITLE
[Typescript] Option for code generation with external module

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -162,6 +162,10 @@ yargs
         describe: "Name of the template literal tag used to identify template literals containing GraphQL queries in Javascript/Typescript code",
         default: 'gql'
       },
+      "code-generation-module": {
+        demand: false,
+        describe: "Path to module for generating actual GraphQL queries [currently typescript only]",
+      },
       "project-name": {
         demand: false,
         describe: "Name of the project to use in a multi-project .graphqlconfig file",
@@ -202,6 +206,7 @@ yargs
         mergeInFieldsFromFragmentSpreads: argv["merge-in-fields-from-fragment-spreads"],
         useFlowExactObjects: argv['use-flow-exact-objects'],
         useFlowReadOnlyTypes: argv['use-flow-read-only-types'],
+        codeGenerationModule: argv['code-generation-module'],
       };
 
       generate(inputPaths, argv.schema, argv.output, argv.only, argv.target, argv.tagName, argv.projectName, options);

--- a/src/compiler/legacyIR.ts
+++ b/src/compiler/legacyIR.ts
@@ -23,6 +23,7 @@ export interface CompilerOptions {
   customScalarsPrefix?: string;
   namespace?: string;
   generateOperationIds?: boolean;
+  codeGenerationModule?: string;
 }
 
 export interface LegacyCompilerContext {

--- a/src/generate.ts
+++ b/src/generate.ts
@@ -97,7 +97,7 @@ export default function generate(
         break;
       case 'ts':
       case 'typescript':
-        output = generateTypescriptSource(context);
+        output = generateTypescriptSource(context, tagName);
         break;
       case 'flow':
         output = generateFlowSource(context);

--- a/src/typescript/codeGeneration.ts
+++ b/src/typescript/codeGeneration.ts
@@ -28,6 +28,7 @@ import {
   interfaceDeclaration,
   propertyDeclaration,
   propertySetsDeclaration,
+  codeGenerationDeclaration,
   Property
 } from './language';
 
@@ -35,11 +36,20 @@ import {
   typeNameFromGraphQLType,
 } from './types';
 
-export function generateSource(context: LegacyCompilerContext) {
+export function generateSource(context: LegacyCompilerContext, tagName: string) {
   const generator = new CodeGenerator<LegacyCompilerContext>(context);
 
   generator.printOnNewline('/* tslint:disable */');
   generator.printOnNewline('//  This file was automatically generated and should not be edited.');
+
+  const {codeGenerationModule} = context.options;
+  if (codeGenerationModule) {
+    generator.printOnNewline('');
+    generator.printOnNewline(`import codeGenerationModule from "${codeGenerationModule}"`);
+    if (tagName) {
+      generator.printOnNewline(`import ${tagName} from "graphql-tag";`);
+    }
+  }
 
   context.typesUsed.forEach(type =>
     typeDeclarationForGraphQLType(generator, type)
@@ -47,6 +57,9 @@ export function generateSource(context: LegacyCompilerContext) {
   Object.values(context.operations).forEach(operation => {
     interfaceVariablesDeclarationForOperation(generator, operation);
     interfaceDeclarationForOperation(generator, operation);
+    if (codeGenerationModule) {
+      codeGenerationDeclarationForOperation(generator, tagName, operation);
+    }
   });
   Object.values(context.fragments).forEach(operation =>
     interfaceDeclarationForFragment(generator, operation)
@@ -199,6 +212,20 @@ export function interfaceDeclarationForOperation(
   }, () => {
     propertyDeclarations(generator, properties);
   });
+}
+
+export function codeGenerationDeclarationForOperation(
+  generator: CodeGenerator,
+  tagName: string,
+  {
+    operationName,
+    operationType,
+    variables,
+    source,
+  }: LegacyOperation
+) {
+  const interfaceName = interfaceNameFromOperation({ operationName, operationType });
+  codeGenerationDeclaration(generator, {interfaceName, tagName, operationType, variables, source});
 }
 
 export function interfaceDeclarationForFragment(

--- a/src/typescript/language.ts
+++ b/src/typescript/language.ts
@@ -46,6 +46,32 @@ export function interfaceDeclaration(generator: CodeGenerator, {
   generator.print(';');
 }
 
+export function codeGenerationDeclaration(generator: CodeGenerator, {
+  interfaceName,
+  tagName,
+  operationType,
+  variables,
+  source,
+}: { interfaceName: string; tagName: string; operationType: string; variables: any[], source: string; }) {
+  generator.printNewlineIfNeeded();
+  generator.printNewline();
+
+
+  generator.print(`export const do${interfaceName} = codeGenerationModule<`);
+  generator.print(`${interfaceName}`);
+  if (variables && variables.length) {
+    generator.print(`, ${interfaceName}Variables`);
+  } else {
+    generator.print(`, null`);
+  }
+  generator.print(`, {operationType: "${operationType}"}`);
+
+  generator.print(`>(`);
+  generator.printOnNewline(`${tagName}\`${source}\`,`);
+  generator.printOnNewline(`{operationType: "${operationType}"}`);
+  generator.printOnNewline(`);`);
+}
+
 export function propertyDeclaration(generator: CodeGenerator, {
   fieldName,
   type,


### PR DESCRIPTION
This is an highly requested feature (#308 ) for Typescript that allowing to generate code for requests 

Option ` --code-generation-module MODULE_NAME`
Thats will insert into generated types new export:
```ts
import codeGenerationModule from "MODULE_NAME";
export const doExampleQuery = codeGenerationModule<ExampleQuery, ExampleQueryVariables, {operationType: "query"}>(QUERY_BODY, {operationType: "query"});

```

In your code:
Before
```ts
const withExampleData = graphql<Props, ExampleQuery, ExampleQueryVariables, ChildProps>(
	EXAMPLE_QUERY,
	options
);
```
After
```ts
const withExampleData = doExampleQuery<Props, ChildProps>(
	options
);
```

To use this add option ` --code-generation-module ./components/create-graphql-query`
And create file (`create-graphql-query.ts`) with default export
```ts
import {graphql} from 'react-apollo';
import {DataProps, MutateProps, OperationOption} from 'react-apollo/types';

export default function createApolloFetch<TData, TGraphQLVariables, TOptions>(query: any, _options: any):
	<
		TProps extends TGraphQLVariables | {} = {},
		TChildProps = TOptions extends {operationType: 'query'}
			? DataProps<TData, TGraphQLVariables>
			: MutateProps<TData, TGraphQLVariables>
	>(operationOptions?: OperationOption<TProps, TData, TGraphQLVariables, TChildProps>)
		=> (WrappedComponent: React.ComponentType<TChildProps & TProps>) => React.ComponentClass<TProps>
{
	return (operationOptions) => graphql(query, operationOptions)
}
```

