### PR TITLE
Fix loadConfigFromFile

### DIFF
--- a/packages/apollo/src/config.ts
+++ b/packages/apollo/src/config.ts
@@ -139,7 +139,7 @@ export function loadConfigFromFile(
   defaultSchema: boolean
 ): ApolloConfig {
   if (file.endsWith(".js")) {
-    const filepath = resolve(file)
+    const filepath = resolve(file);
     delete require.cache[require.resolve(filepath)];
     return loadConfig(
       require(filepath),


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-cli/issues/549

Current implementation resolves the config file as a node module, making it impossible to actually pass a config file

<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [x] feature
- [x] blocking
- [ ] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->