### PR TITLE
Update VSCode README

### DIFF
--- a/packages/vscode-apollo/README.md
+++ b/packages/vscode-apollo/README.md
@@ -1,48 +1,19 @@
 # Apollo VSCode
 
-An all-in-one tooling experience for developing apps with Apollo
-
-- Get instant feedback and intelligent autocomplete as you write queries
-- Seamlessly manage your client side schema alongside your remote one
-- View performance statistics next to your query definitions
-
 ## Features
 
-- Loads your GraphQL schemas and queries automatically from an [Apollo Config](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/README.md#configuration) file
+- Loads your GraphQL schemas and queries automatically from an [Apollo Config](https://www.apollographql.com/docs/resources/apollo-config.html) file
 - Adds syntax highlighting for GraphQL files and `gql` templates inside JavaScript files
 - Code-completes fields, arguments, types, and variables in your queries
 - Detects and loads client side schemas and validates client side field usage in operations
-- Displays performance statistics from [Apollo Engine](https://www.apollographql.com/engine) inline with your queries
+- Displays performance statistics from [Apollo Engine](https://www.apollographql.com/docs/engine/) inline with your queries
 - Jump-to-definition for fragments and schema types
 - Detects fragment references and shows them next to definitions
 
-## How to get it?
+## Configuration
 
-Open up VS Code and search for the extension "Apollo".
+Please refer to the [Editor Plugin](https://www.apollographql.com/docs/platform/editor-plugins.html) docs for configuration instructions.
 
-## How to get it set up?
+## Issues
 
-The extension searches for [Apollo Config](https://github.com/apollographql/apollo-tooling/blob/master/packages/apollo/README.md#configuration) definitions in `package.json` or `apollo.config.js` files. Apollo Config can be set up to pull a schema from an introspection or from a [published version on Apollo Engine](https://www.apollographql.com/docs/engine/features/schema-history.html).
-
-```js
-// package.json
-
-{
-  ...,
-  "apollo": {
-    "client": {
-      "service": "my-service-name"
-    }
-  }
-}
-```
-
-## Troubleshooting
-
-### Extension not starting correctly? Check the logs!
-
-If you're having trouble with the extension not launching or not detecting your configuration files, you can check the language server logs.
-
-1.  Open the VS Code output tab by running the command "View: Toggle Output"
-2.  Switch the output view to "Apollo GraphQL"
-3.  Check the logs and report any bugs you find!
+Please report any issues you find to the [Apollo Tooling](https://github.com/apollographql/apollo-tooling) repo. Pull requests are always welcome!

--- a/packages/vscode-apollo/package.json
+++ b/packages/vscode-apollo/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vscode-apollo",
-  "displayName": "Apollo GraphQL",
-  "description": "A VS Code extension for Apollo GraphQL projects",
+  "displayName": "Apollo VSCode",
+  "description": "A VSCode extension for Apollo GraphQL projects",
   "version": "1.1.9",
   "referenceID": "87197759-7617-40d0-b32e-46d378e907c7",
   "author": "Apollo GraphQL <opensource@apollographql.com>",


### PR DESCRIPTION
1) Update links and content for the marketplace README file

2) Update name of the extension itself from 'Apollo GraphQL' to 'Apollo VSCode'. Having the org and extension name looks funny on the marketplace page.
![image](https://user-images.githubusercontent.com/29644393/48370171-5b286d80-e66d-11e8-9ba7-c9c4b93e70ce.png)


<!--**Pull Request Labels**

While not necessary, you can help organize our pull requests by labeling this issue when you open it.  To add a label automatically, simply [x] mark the appropriate box below:

- [ ] feature
- [ ] blocking
- [x] docs

To add a label not listed above, simply place `/label another-label-name` on a line by itself.
-->