### PR TITLE
packages: apollo-env: use core-js@3.0.0-beta.3 only

### DIFF
--- a/packages/apollo-env/package.json
+++ b/packages/apollo-env/package.json
@@ -20,7 +20,7 @@
     "node": ">=8"
   },
   "dependencies": {
-    "core-js": "^3.0.0-beta.3",
+    "core-js": "3.0.0-beta.3",
     "node-fetch": "^2.2.0"
   }
 }


### PR DESCRIPTION
In the latest version (that is core-js@3.0.0-beta.13 or
core-js@2.6.3 at the point of writing this) the path for
`array-flat-and-flat-map` changed.

core-js/proposals/array-flat-and-flat-map is no longer accessible
and thus causes errors for anyone using this package, for example
@vue/cli.

Test: `yarn add core-js@3.0.0-beta.3`, works now

<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
