### PR TITLE
feat: add tsUseOptionalForNullables option to ts codegen

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@
 - `apollo-codegen-swift`
   - <First `apollo-codegen-swift` related entry goes here>
 - `apollo-codegen-typescript`
-  - <First `apollo-codegen-typescript` related entry goes here>
+  - add `tsUseOptionalForNullables` config [#1766](https://github.com/apollographql/apollo-tooling/pull/1766) and [#622](https://github.com/apollographql/apollo-tooling/issues/622)
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -45,6 +45,7 @@ export interface CompilerOptions {
   // this option is only implemented in the ts codegen, so we name it
   // `ts` fileExtension for now.
   tsFileExtension?: string;
+  tsUseOptionalForNullables?: boolean;
   useReadOnlyTypes?: boolean;
   suppressSwiftMultilineStringLiterals?: boolean;
   omitDeprecatedEnumCases?: boolean;

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -1779,6 +1779,67 @@ export interface ReviewInput {
 }
 `;
 
+exports[`Typescript codeGeneration local / global use optional for nullables config enabled 1`] = `
+Object {
+  "common": "/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+  NEWHOPE = \\"NEWHOPE\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+  "generatedFiles": Array [
+    Object {
+      "content": TypescriptGeneratedFile {
+        "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// This file was automatically generated and should not be edited.
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero {
+  /**
+   * The name of the character
+   */
+  name: string;
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroName {
+  hero?: HeroName_hero;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode;
+}
+",
+      },
+      "fileName": "HeroName.ts",
+      "sourcePath": "GraphQL request",
+    },
+  ],
+}
+`;
+
 exports[`Typescript codeGeneration multiple files 1`] = `"generatedFiles"`;
 
 exports[`Typescript codeGeneration multiple files 2`] = `

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -634,4 +634,21 @@ describe("Typescript codeGeneration local / global", () => {
     expect(output).toMatchSnapshot();
     expect(generateGlobalSource(context)).toMatchSnapshot();
   });
+
+  test("use optional for nullables config enabled", () => {
+    const context = compile(
+      `
+      query HeroName($episode: Episode) {
+        hero(episode: $episode) {
+          name
+          id
+        }
+      }
+    `,
+      { tsUseOptionalForNullables: true }
+    );
+
+    const output = generateSource(context);
+    expect(output).toMatchSnapshot();
+  });
 });

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -109,6 +109,10 @@ export default class Generate extends ClientCommand {
     tsFileExtension: flags.string({
       description:
         'By default, TypeScript will output "ts" files. Set "tsFileExtension" to specify a different file extension, for example "d.ts"'
+    }),
+    tsUseOptionalForNullables: flags.boolean({
+      description:
+        "This makes nullable fields optional instead of union of field type and null. Makes forwarding query/mutation results to components with optional props easier. When enabling this You should be aware that apollo-client assigns null to fields with empty value and `undefined !== null` in JavaScript. So a type guard like `type fieldValue !== 'object'` without any further checks, compiles but may result in runtime errors."
     })
   };
 
@@ -221,6 +225,7 @@ export default class Generate extends ClientCommand {
                       flags.useReadOnlyTypes || flags.useFlowReadOnlyTypes,
                     globalTypesFile: flags.globalTypesFile,
                     tsFileExtension: flags.tsFileExtension,
+                    tsUseOptionalForNullables: flags.tsUseOptionalForNullables,
                     suppressSwiftMultilineStringLiterals:
                       flags.suppressSwiftMultilineStringLiterals,
                     omitDeprecatedEnumCases: flags.omitDeprecatedEnumCases


### PR DESCRIPTION
`tsUseOptionalForNullables` makes nullable fields optional instead of a union of field type and null.  
As discussed in #1622, this issue makes sending an Apollo client query with nullable field to standard React components typed with TypeScript very painfull. You have to add `| null` to optional props of every component you have and add a wrapper for every Library component you use (Material UI uses optional props for example).  

Avoiding the edge cases (like `typeof field === 'object'`) that comes with enabling this config (Which is not the case 99% of times) is the developer's responsibility as this is disabled by default.  

This also makes integrating Apollo into existing systems much easier.

TODO:

- [X] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [X] Make sure all of the significant new logic is covered by tests
- [X] Rebase your changes on master so that they can be merged easily
- [X] Make sure all tests and linter rules pass