### PR TITLE
Fixed mutable config merge

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3848,6 +3848,15 @@
       "integrity": "sha512-kMNLM5JBcasgYscD9x/Gvr6lTAv2NVgsKtet/hm93qMyf/D1pt+7jeEZklKJKxMVmXjxbRVQQGfqDSfipYCO6w==",
       "dev": true
     },
+    "@types/lodash.clonedeep": {
+      "version": "4.5.6",
+      "resolved": "https://registry.npmjs.org/@types/lodash.clonedeep/-/lodash.clonedeep-4.5.6.tgz",
+      "integrity": "sha512-cE1jYr2dEg1wBImvXlNtp0xDoS79rfEdGozQVgliDZj1uERH4k+rmEMTudP9b4VQ8O6nRb5gPqft0QzEQGMQgA==",
+      "dev": true,
+      "requires": {
+        "@types/lodash": "*"
+      }
+    },
     "@types/lodash.debounce": {
       "version": "4.0.6",
       "resolved": "https://registry.npmjs.org/@types/lodash.debounce/-/lodash.debounce-4.0.6.tgz",
@@ -4674,6 +4683,7 @@
         "glob": "^7.1.3",
         "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
         "graphql-tag": "^2.10.1",
+        "lodash.clonedeep": "^4.5.0",
         "lodash.debounce": "^4.0.8",
         "lodash.merge": "^4.6.1",
         "minimatch": "^3.0.4",
@@ -13943,8 +13953,7 @@
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.debounce": {
       "version": "4.0.8",

--- a/package.json
+++ b/package.json
@@ -65,6 +65,7 @@
     "@types/listr": "0.14.2",
     "@types/lodash": "4.14.150",
     "@types/lodash.debounce": "4.0.6",
+    "@types/lodash.clonedeep": "^4.5.6",
     "@types/lodash.identity": "3.0.6",
     "@types/lodash.merge": "4.6.6",
     "@types/lodash.pickby": "4.6.6",

--- a/packages/apollo-language-server/package.json
+++ b/packages/apollo-language-server/package.json
@@ -36,6 +36,7 @@
     "glob": "^7.1.3",
     "graphql": "14.0.2 - 14.2.0 || ^14.3.1",
     "graphql-tag": "^2.10.1",
+    "lodash.clonedeep": "^4.5.0",
     "lodash.debounce": "^4.0.8",
     "lodash.merge": "^4.6.1",
     "minimatch": "^3.0.4",

--- a/packages/apollo-language-server/src/config/loadConfig.ts
+++ b/packages/apollo-language-server/src/config/loadConfig.ts
@@ -3,6 +3,7 @@ import { LoaderEntry } from "cosmiconfig";
 import TypeScriptLoader from "@endemolshinegroup/cosmiconfig-typescript-loader";
 import { resolve } from "path";
 import { readFileSync, existsSync, lstatSync } from "fs";
+import cloneDeep from "lodash.clonedeep";
 import merge from "lodash.merge";
 import {
   ApolloConfig,
@@ -208,11 +209,13 @@ export async function loadConfig({
   // selectively apply defaults when loading the config
   // this is just the includes/excludes defaults.
   // These need to go on _all_ configs. That's why this is last.
-  if (config.client) config = merge({ client: DefaultClientConfig }, config);
-  if (config.service) config = merge({ service: DefaultServiceConfig }, config);
-  if (engineConfig) config = merge(engineConfig, config);
+  if (config.client)
+    config = merge(cloneDeep({ client: DefaultClientConfig }), config);
+  if (config.service)
+    config = merge(cloneDeep({ service: DefaultServiceConfig }), config);
+  if (engineConfig) config = merge(cloneDeep(engineConfig), config);
 
-  config = merge({ engine: DefaultEngineConfig }, config);
+  config = merge(cloneDeep({ engine: DefaultEngineConfig }), config);
 
   return new ApolloConfig(config, URI.file(resolve(filepath)));
 }


### PR DESCRIPTION
lodash.merge is mutable in nature, which means the default config is being updated every time it's merged into a project config, causing some fields like `localSchemaFile` to travel onto other project configs that don't require it, causing issues with conflicting schemas, etc...