### PR TITLE
Add option to keep schema enum order for code generating

### DIFF
--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -56,6 +56,7 @@ export interface CompilerOptions {
   suppressSwiftMultilineStringLiterals?: boolean;
   omitDeprecatedEnumCases?: boolean;
   exposeTypeNodes?: boolean;
+  keepSchemaEnumOrder?: boolean;
 }
 
 export interface CompilerContext {

--- a/packages/apollo-codegen-core/src/utilities/graphql.ts
+++ b/packages/apollo-codegen-core/src/utilities/graphql.ts
@@ -35,7 +35,7 @@ declare module "graphql/utilities/buildASTSchema" {
 }
 
 export function sortEnumValues(values: GraphQLEnumValue[]): GraphQLEnumValue[] {
-  return values.sort((a, b) =>
+  return Array.from(values).sort((a, b) =>
     a.value < b.value ? -1 : a.value > b.value ? 1 : 0
   );
 }

--- a/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
+++ b/packages/apollo-codegen-typescript/src/__tests__/__snapshots__/codeGeneration.ts.snap
@@ -2287,3 +2287,71 @@ export interface ReviewMovieVariables {
   ],
 }
 `;
+exports[`Typescript codeGeneration local / global keep enum order 1`] = `
+Array [
+  Object {
+    "content": TypescriptGeneratedFile {
+      "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+import { Episode } from \\"./../../__generated__/globalTypes\\";
+
+// ====================================================
+// GraphQL query operation: HeroName
+// ====================================================
+
+export interface HeroName_hero {
+  __typename: \\"Human\\" | \\"Droid\\";
+  /**
+   * The name of the character
+   */
+  name: string;
+  /**
+   * The ID of the character
+   */
+  id: string;
+}
+
+export interface HeroName {
+  hero: HeroName_hero | null;
+}
+
+export interface HeroNameVariables {
+  episode?: Episode | null;
+}
+",
+    },
+    "fileName": "HeroName.ts",
+    "sourcePath": "GraphQL request",
+  },
+]
+`;
+
+exports[`Typescript codeGeneration local / global keep enum order 2`] = `
+TypescriptGeneratedFile {
+  "fileContents": "/* tslint:disable */
+/* eslint-disable */
+// @generated
+// This file was automatically generated and should not be edited.
+
+//==============================================================
+// START Enums and Input Objects
+//==============================================================
+
+/**
+ * The episodes in the Star Wars trilogy
+ */
+export enum Episode {
+  NEWHOPE = \\"NEWHOPE\\",
+  EMPIRE = \\"EMPIRE\\",
+  JEDI = \\"JEDI\\",
+}
+
+//==============================================================
+// END Enums and Input Objects
+//==============================================================
+",
+}
+`;

--- a/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/__tests__/codeGeneration.ts
@@ -634,4 +634,32 @@ describe("Typescript codeGeneration local / global", () => {
     expect(output).toMatchSnapshot();
     expect(generateGlobalSource(context)).toMatchSnapshot();
   });
+
+  test("keep enum order", () => {
+    const context = compile(
+      `
+      query HeroName($episode: Episode) {
+        hero(episode: $episode) {
+          name
+          id
+        }
+      }
+    `,
+      {
+        mergeInFieldsFromFragmentSpreads: true,
+        addTypename: true,
+        keepSchemaEnumOrder: true
+      }
+    );
+
+    const output = generateLocalSource(context).map(f => ({
+      ...f,
+      content: f.content({
+        outputPath: "/some/file/ComponentA.tsx",
+        globalSourcePath: "/__generated__/globalTypes.ts"
+      })
+    }));
+    expect(output).toMatchSnapshot();
+    expect(generateGlobalSource(context)).toMatchSnapshot();
+  });
 });

--- a/packages/apollo-codegen-typescript/src/codeGeneration.ts
+++ b/packages/apollo-codegen-typescript/src/codeGeneration.ts
@@ -50,7 +50,8 @@ class TypescriptGeneratedFile implements BasicGeneratedFile {
 
 function printEnumsAndInputObjects(
   generator: TypescriptAPIGenerator,
-  typesUsed: GraphQLType[]
+  typesUsed: GraphQLType[],
+  keepSchemaEnumOrder: boolean = false
 ) {
   generator.printer.enqueue(stripIndent`
     //==============================================================
@@ -62,7 +63,7 @@ function printEnumsAndInputObjects(
     .filter(isEnumType)
     .sort()
     .forEach(enumType => {
-      generator.typeAliasForEnumType(enumType);
+      generator.typeAliasForEnumType(enumType, keepSchemaEnumOrder);
     });
 
   typesUsed
@@ -213,7 +214,11 @@ export function generateGlobalSource(
 ): TypescriptGeneratedFile {
   const generator = new TypescriptAPIGenerator(context);
   generator.fileHeader();
-  printEnumsAndInputObjects(generator, context.typesUsed);
+  printEnumsAndInputObjects(
+    generator,
+    context.typesUsed,
+    context.options.keepSchemaEnumOrder
+  );
   const output = generator.printer.printAndClear();
   return new TypescriptGeneratedFile(output);
 }
@@ -242,8 +247,13 @@ export class TypescriptAPIGenerator extends TypescriptGenerator {
     );
   }
 
-  public typeAliasForEnumType(enumType: GraphQLEnumType) {
-    this.printer.enqueue(this.enumerationDeclaration(enumType));
+  public typeAliasForEnumType(
+    enumType: GraphQLEnumType,
+    keepSchemaEnumOrder: boolean
+  ) {
+    this.printer.enqueue(
+      this.enumerationDeclaration(enumType, keepSchemaEnumOrder)
+    );
   }
 
   public typeAliasForInputObjectType(inputObjectType: GraphQLInputObjectType) {

--- a/packages/apollo-codegen-typescript/src/language.ts
+++ b/packages/apollo-codegen-typescript/src/language.ts
@@ -28,9 +28,15 @@ export default class TypescriptGenerator {
     );
   }
 
-  public enumerationDeclaration(type: GraphQLEnumType) {
+  public enumerationDeclaration(
+    type: GraphQLEnumType,
+    keepSchemaEnumOrder: boolean
+  ) {
     const { name, description } = type;
-    const enumMembers = sortEnumValues(type.getValues()).map(({ value }) => {
+    const enumSortedMembers = keepSchemaEnumOrder
+      ? type.getValues()
+      : sortEnumValues(type.getValues());
+    const enumMembers = enumSortedMembers.map(({ value }) => {
       return t.TSEnumMember(t.identifier(value), t.stringLiteral(value));
     });
 

--- a/packages/apollo/src/commands/client/codegen.ts
+++ b/packages/apollo/src/commands/client/codegen.ts
@@ -108,6 +108,10 @@ export default class Generate extends ClientCommand {
     tsFileExtension: flags.string({
       description:
         'By default, TypeScript will output "ts" files. Set "tsFileExtension" to specify a different file extension, for example "d.ts"'
+    }),
+    keepSchemaEnumOrder: flags.boolean({
+      description: "[default: false] Keep enum order from schema",
+      default: false
     })
   };
 


### PR DESCRIPTION
Hi,

This is a PR related to issue #1760. We want to can keep schema enum order when generating code and not sort them alphabetically. This PR keep sort by default but add an option to don't.

I added a test and I update only for typescript generation. I don't know if it could be interesting for another generation.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
- [ ] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
