### PR TITLE
Improve output window titles & stop output from stealing focus

### DIFF
--- a/packages/vscode-apollo/src/extension.ts
+++ b/packages/vscode-apollo/src/extension.ts
@@ -54,7 +54,7 @@ export function activate(context: ExtensionContext) {
   statusBar = new StatusBar({
     hasActiveTextEditor: Boolean(window.activeTextEditor)
   });
-  outputChannel = window.createOutputChannel("Apollo GraphQL");
+  outputChannel = window.createOutputChannel("Apollo GraphQL Extension");
   Debug.SetOutputConsole(outputChannel);
   clientDisposable = client.start();
 

--- a/packages/vscode-apollo/src/languageServerClient.ts
+++ b/packages/vscode-apollo/src/languageServerClient.ts
@@ -2,7 +2,8 @@ import {
   ServerOptions,
   TransportKind,
   LanguageClientOptions,
-  LanguageClient
+  LanguageClient,
+  RevealOutputChannelOn
 } from "vscode-languageclient";
 import { workspace, OutputChannel } from "vscode";
 
@@ -61,12 +62,13 @@ export function getLanguageServerClient(
         )
       ]
     },
-    outputChannel
+    outputChannel,
+    revealOutputChannelOn: RevealOutputChannelOn.Never
   };
 
   return new LanguageClient(
     "apollographql",
-    "Apollo GraphQL",
+    "Apollo GraphQL Language Server",
     serverOptions,
     clientOptions
   );


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

The Output window in VSCode, when using this extension, shows two outputs for this extension, both named "Apollo GraphQL."

This PR hopes to clarify those two outputs by giving them more descriptive names, "Apollo GraphQL Extension," and "Apollo GraphQL Language Server."

Additionally, as noted in [this comment](https://github.com/apollographql/apollo-tooling/issues/1874#issuecomment-655722266), there is currently a problem where errors get re-thrown repeatedly (I believe they get thrown on every reloadSchema action, which happens when any watched files are changed). 

I don't have a fix for that issue, but I do have a fix for the output window stealing focus from the terminal window. It isn't necessary to have the output window steal focus, since the errors are already being displayed in the notification center.

TODO:

- [ ] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
