### PR TITLE
Fix `removeDirectiveAnnotatedFields` to remove variables from definition

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - Fix `removeDirectiveAnnotatedFields` to remove variables from the operation definition if the variable was only used in the removed field.
+  - Fix `removeDirectiveAnnotatedFields` to remove variables from the operation definition if the variables are unused after removing directive annotated fields. [#2146](https://github.com/apollographql/apollo-tooling/pull/2146)
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,7 +21,7 @@
 - `apollo-graphql`
   - <First `apollo-graphql` related entry goes here>
 - `apollo-language-server`
-  - <First `apollo-language-server` related entry goes here>
+  - Fix `removeDirectiveAnnotatedFields` to remove variables from the operation definition if the variable was only used in the removed field.
 - `apollo-tools`
   - <First `apollo-tools` related entry goes here>
 - `vscode-apollo`

--- a/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
+++ b/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
@@ -117,7 +117,7 @@ describe("removeDirectiveAnnotatedFields", () => {
     `);
   });
 
-  it("remove variables from definition if they are only used in client only fields", () => {
+  it("should remove variables from definition if they are only used in annotated fields", () => {
     expect(
       print(
         removeDirectiveAnnotatedFields(

--- a/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
+++ b/packages/apollo-language-server/src/utilities/__tests__/graphql.test.ts
@@ -117,6 +117,27 @@ describe("removeDirectiveAnnotatedFields", () => {
     `);
   });
 
+  it("remove variables from definition if they are only used in client only fields", () => {
+    expect(
+      print(
+        removeDirectiveAnnotatedFields(
+          parse(`
+            query Query($var1: String!, $var2: String!) {
+              fieldToKeep(var1: $var1)
+              fieldToRemove(var1: $var1, var2: $var2) @client
+            }
+          `),
+          ["client"]
+        )
+      )
+    ).toMatchInlineSnapshot(`
+      "query Query($var1: String!) {
+        fieldToKeep(var1: $var1)
+      }
+      "
+    `);
+  });
+
   it("should remove fragments when a directive is used on a fragment spread", () => {
     expect(
       print(

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -165,9 +165,11 @@ function removeOrphanedFragmentDefinitionsAndVariables<AST extends ASTNode>(
       return {
         ...node,
         // Remove matching top level variables definitions.
-        variableDefinitions: node.variableDefinitions.filter(
-          varDef => !variablesToRemove.has(varDef.variable.name.value)
-        )
+        variableDefinitions:
+          node.variableDefinitions &&
+          node.variableDefinitions.filter(
+            varDef => !variablesToRemove.has(varDef.variable.name.value)
+          )
       };
     }
   });

--- a/packages/apollo-language-server/src/utilities/graphql.ts
+++ b/packages/apollo-language-server/src/utilities/graphql.ts
@@ -349,7 +349,7 @@ export function removeDirectiveAnnotatedFields<AST extends ASTNode>(
     }
   });
 
-  // Remove all orphaned fragment definitions
+  // Remove all orphaned fragment definitions and variables
   ast = removeOrphanedFragmentDefinitionsAndVariables(
     ast,
     removedFragmentSpreadNames,


### PR DESCRIPTION
<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass

\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.

# Description
This PR adds functionality to handle the edge case when all usages of a variables are removed by `removeDirectiveAnnotatedFields`. 

Apollo tooling, like `apollo client:extract` will strip specified directives (e.g. `@client`) from GraphQL queries. The function `removeDirectiveAnnotatedFields` is used to remove these fields. Fields that use variables may also be removed. If all usages of a variable are removed, then the variable should be removed from the operation definition because [a definition with an unused variable is invalid](https://spec.graphql.org/June2018/#sec-All-Variables-Used).

The tests include a more comprehensive example.

## Notes
This logic exists in apollo-utilities/src/transform.ts:removeDirectivesFromDocument. Another implementation would be to add a dependency on apollo-utilities and use that function.

