### PR TITLE
[introduce] cli: service:{check,push} --remoteUrl and [fix] cli: service:check fix --author --commitId

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -45,6 +45,10 @@
 
 - This package no longer depends on `apollo-env` to avoid the side-effects of its polyfills.
 
+## `apollo@2.32.12`
+  - `--remoteUrl` in `service:check` and `service:push` overrides the current remove URL otherwise read through [env-ci](https://www.npmjs.com/package/env-ci).
+  - `service:check` now takes `--author` and `--commitId` correctly when checking a monolithic schema.
+
 ## `apollo@2.32.5`
 
 - `apollo@2.32.5`

--- a/packages/apollo/src/commands/service/check.ts
+++ b/packages/apollo/src/commands/service/check.ts
@@ -252,6 +252,9 @@ export default class ServiceCheck extends ProjectCommand {
     branch: flags.string({
       description: "The branch name to associate with this check"
     }),
+    remoteUrl: flags.string({
+      description: "The URL of your project's remote repository"
+    }),
     commitId: flags.string({
       description: "The SHA-1 hash of the commit to associate with this check"
     }),
@@ -384,7 +387,8 @@ export default class ServiceCheck extends ProjectCommand {
                     ...gitInfoFromEnv,
                     ...(flags.author ? { committer: flags.author } : undefined),
                     ...(flags.branch ? { branch: flags.branch } : undefined),
-                    ...(flags.commitId ? { commit: flags.commitId } : undefined)
+                    ...(flags.commitId ? { commit: flags.commitId } : undefined),
+                    ...(flags.remoteUrl ? { remoteUrl: flags.remoteUrl } : undefined)
                   }
                 });
 
@@ -480,10 +484,10 @@ export default class ServiceCheck extends ProjectCommand {
                   tag: config.variant,
                   gitContext: {
                     ...gitInfoFromEnv,
-                    ...(flags.committer
-                      ? { committer: flags.committer }
-                      : undefined),
-                    ...(flags.branch ? { branch: flags.branch } : undefined)
+                    ...(flags.author ? { committer: flags.author } : undefined),
+                    ...(flags.branch ? { branch: flags.branch } : undefined),
+                    ...(flags.commitId ? { commit: flags.commitId } : undefined),
+                    ...(flags.remoteUrl ? { remoteUrl: flags.remoteUrl } : undefined)
                   },
                   ...(historicParameters && { historicParameters }),
                   ...schemaCheckSchemaVariables

--- a/packages/apollo/src/commands/service/push.ts
+++ b/packages/apollo/src/commands/service/push.ts
@@ -32,6 +32,9 @@ export default class ServicePush extends ProjectCommand {
     branch: flags.string({
       description: "The branch name to associate with this publication"
     }),
+    remoteUrl: flags.string({
+      description: "The URL of your project's remote repository"
+    }),
     commitId: flags.string({
       description:
         "The SHA-1 hash of the commit to associate with this publication"
@@ -89,7 +92,8 @@ export default class ServicePush extends ProjectCommand {
             ...gitInfoFromEnv,
             ...(flags.author ? { committer: flags.author } : undefined),
             ...(flags.branch ? { branch: flags.branch } : undefined),
-            ...(flags.commitId ? { commit: flags.commitId } : undefined)
+            ...(flags.commitId ? { commit: flags.commitId } : undefined),
+            ...(flags.remoteUrl ? { remoteUrl: flags.remoteUrl } : undefined)
           };
 
           // handle partial schema uploading


### PR DESCRIPTION
Fixes https://github.com/apollographql/apollo-tooling/issues/2285

- Fixes `service:check` now takes `--author` and `--commitId` correctly when checking a monolithic schema.
- Adds `--remoteUrl` to `service:{check,push}`, to it easy to override this information, as CI environments can provide erroneous information.

