### PR TITLE
Add support for interface on interfaces to transformSchema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@
 - `apollo-env`
   - <First `apollo-env` related entry goes here>
 - `apollo-graphql`
-  - <First `apollo-graphql` related entry goes here>
+  - Add support for interface on interfaces to transformSchema. [PR #2456](https://github.com/apollographql/apollo-tooling/pull/2456)
 - `apollo-language-server`
   - <First `apollo-language-server` related entry goes here>
 - `apollo-tools`

--- a/packages/apollo-graphql/src/schema/__tests__/transformSchema.test.ts
+++ b/packages/apollo-graphql/src/schema/__tests__/transformSchema.test.ts
@@ -14,10 +14,27 @@ describe("transformSchema", () => {
 
     # https://github.com/apollographql/apollo-tooling/issues/2162
     directive @test(baz: DirectiveArg) on FIELD_DEFINITION
+
+    interface FooInterface {
+      foo: String
+    }
+
+    interface BarInterface implements FooInterface {
+      foo: String
+      bar: Boolean
+    }
+
+    type FooBarBazType implements FooInterface & BarInterface {
+      foo: String
+      bar: Boolean
+      baz: Float
+    }
     `);
 
+    const originalSDL = printSchema(schema);
     const newSchema = transformSchema(schema, namedType => namedType);
 
-    expect(printSchema(newSchema)).toEqual(printSchema(schema));
+    expect(printSchema(schema)).toEqual(originalSDL);
+    expect(printSchema(newSchema)).toEqual(originalSDL);
   });
 });

--- a/packages/apollo-graphql/src/schema/transformSchema.ts
+++ b/packages/apollo-graphql/src/schema/transformSchema.ts
@@ -72,6 +72,7 @@ export function transformSchema(
 
       return new GraphQLInterfaceType({
         ...config,
+        interfaces: () => config.interfaces.map(replaceNamedType),
         fields: () => replaceFields(config.fields)
       });
     } else if (isUnionType(type)) {


### PR DESCRIPTION
This change fixes `transformSchema`, which previously left
`GraphQLInterface::interfaces` field as-is after transforming types.
This meant that interfaces types used implemented by other interfaces
would appear duplicated in the schema.

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [x] Make sure all of the significant new logic is covered by tests
- [x] Rebase your changes on master so that they can be merged easily
- [x] Make sure all tests and linter rules pass