### PR TITLE
Sort types when generating

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 > **Note:** Apollo's GraphQL VSCode extension is no longer housed in this repository. It is now maintained separately in [this repo](https://github.com/apollographql/vscode-graphql).
 
+## `apollo@2.33.10`
+
+- `apollo-codegen-core@0.40.8`
+  - Adjust `apollo-codegen-core` to sort types and union type arrays. [PR#2576](https://github.com/apollographql/apollo-tooling/pull/2576)
+
 ## `apollo@2.33.9`
 
 - `apollo-language-server@1.26.7` / `apollo-codegen-core@0.40.7`

--- a/packages/apollo-codegen-core/package.json
+++ b/packages/apollo-codegen-core/package.json
@@ -1,7 +1,7 @@
 {
   "name": "apollo-codegen-core",
   "description": "Core generator APIs for Apollo Codegen",
-  "version": "0.40.7",
+  "version": "0.40.8",
   "author": "Apollo GraphQL <packages@apollographql.com>",
   "license": "MIT",
   "repository": {

--- a/packages/apollo-codegen-core/src/compiler/index.ts
+++ b/packages/apollo-codegen-core/src/compiler/index.ts
@@ -267,7 +267,7 @@ class Compiler {
   }
 
   get typesUsed(): GraphQLType[] {
-    return Array.from(this.typesUsedSet);
+    return Array.from(this.typesUsedSet).sort();
   }
 
   addUnionType(type: GraphQLType) {
@@ -278,7 +278,7 @@ class Compiler {
   }
 
   get unionTypes(): GraphQLUnionType[] {
-    return Array.from(this.unionTypesSet);
+    return Array.from(this.unionTypesSet).sort();
   }
 
   addInterfaceType(type: GraphQLType) {
@@ -525,7 +525,7 @@ class Compiler {
 
   possibleTypesForType(type: GraphQLCompositeType): GraphQLObjectType[] {
     if (isAbstractType(type)) {
-      return Array.from(this.schema.getPossibleTypes(type)) || [];
+      return Array.from(this.schema.getPossibleTypes(type)).sort() || [];
     } else {
       return [type];
     }


### PR DESCRIPTION
I don't know if this will be merged or considered since it seems like the repo is no longer maintained but I'd love to get this in and addressed as it's quite annoying when doing type generation to constantly run in to this. I'd prefer not to give my information to Apollo via the license agreement, so I'd be okay with this code being taken and merged by an actual contributor if that's possible. Let me know.


Types are not currently sorted when regenerating the graphql
schema. This results in constantly changing types based on what was
queried first leading to unnecessary merge conflicts as the type
order changes. This addresses the issue by sorting the type array
before it is returned.<!--
  Thanks for filing a pull request on Apollo Tooling!

  Please look at the following checklist to ensure that your PR
  can be accepted quickly:
-->

TODO:

- [x] Update CHANGELOG.md\* with your change (include reference to issue & this PR)
- [ ] Make sure all of the significant new logic is covered by tests
  * Did not do this as it seems unnecessary based on the existing tests
- [x] Rebase your changes on master so that they can be merged easily
- [ ] Make sure all tests and linter rules pass
\*Make sure changelog entries note which project(s) has been affected. See older entries for examples on what this looks like.
