### PR TITLE
ci: SECOPS-2525 - add semgrep job

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -2,6 +2,7 @@ version: 2.1
 
 orbs:
   node: circleci/node@5.0.2
+  secops: apollo/circleci-secops-orb@2.0.6
 
 commands:
   install-volta:
@@ -95,3 +96,16 @@ workflows:
       - Linting
       - Query Check
       - Generated Types Check
+  security-scans:
+    jobs:
+      - secops/gitleaks:
+          context:
+            - secops-oidc
+            - github-orb
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>
+          git-revision: << pipeline.git.revision >>
+      - secops/semgrep:
+          context:
+              - secops-oidc
+              - github-orb
+          git-base-revision: <<#pipeline.git.base_revision>><<pipeline.git.base_revision>><</pipeline.git.base_revision >>


### PR DESCRIPTION
## Motivation / Implements

This PR adds or updates the necessary configuration to enable [Semgrep](https://semgrep.dev/docs/semgrep-code/overview/) to run on PRs on this repo. The Apollo Security team uses Semgrep to test our source for potential security vulnerabilities.

Once this is accepted and merged, the Security team plans to make a passing Semgrep check a requirement for PRs to merge into this repo. This will prevent net-new severe issues from being introduced. The job proposed by this PR runs in a diff-aware mode, so it will only alert if net-new issues are introduced in a branch.

In the event that a severe issue _is_ detected on a PR, the CI job will add a comment to the PR associated with the detection to provide instructions on how to properly resolve the detection. The comment added to PRs will also include instructions on how to get further support if needed.

If maintainers reviewing this PR have questions, please reach out in the `#security` channel in Slack or contact Matt Peake directly at `matt[.]peake@apollographql[.]com`.

  

## Changed

- Updated `.circleci/config.yml` to include appropriate configuration to enable Semgrep as a CI check. 