### PR TITLE
feat: show deprecation warning for all commands, not just service:*

### DIFF
--- a/.changeset/deprecate-all-commands.md
+++ b/.changeset/deprecate-all-commands.md
@@ -1,0 +1,5 @@
+---
+'apollo': patch
+---
+
+All commands now print a deprecation warning on startup pointing users to the Apollo Rover CLI (https://go.apollo.dev/t/migration). Previously only `service:*` commands showed this warning; `client:*` commands did not.

--- a/packages/apollo/src/Command.ts
+++ b/packages/apollo/src/Command.ts
@@ -100,6 +100,7 @@ export abstract class ProjectCommand extends Command {
   protected type: "service" | "client" = "service";
   protected configMap?: (flags: any) => DeepPartial<ApolloConfig>;
   private ctx!: ProjectContext;
+  private _deprecationWarningPrinted = false;
 
   async init() {
     const { flags, args } = this.parse<Flags, { [name: string]: any }>(
@@ -130,6 +131,8 @@ export abstract class ProjectCommand extends Command {
         ctx = { ...ctx, ...this.ctx };
       },
     });
+
+    this.printDeprecationWarning();
   }
 
   protected async createConfig(flags: Flags) {
@@ -292,7 +295,10 @@ export abstract class ProjectCommand extends Command {
     "-----------------------------------------------------------------\n";
 
   protected printDeprecationWarning() {
-    console.error(ProjectCommand.DEPRECATION_MSG);
+    if (!this._deprecationWarningPrinted) {
+      console.error(ProjectCommand.DEPRECATION_MSG);
+      this._deprecationWarningPrinted = true;
+    }
   }
 }
 


### PR DESCRIPTION
## Summary

- `client:*` commands (e.g. `client:check`, `client:push`, `client:codegen`) previously showed no deprecation warning at all
- Moves `printDeprecationWarning()` into `ProjectCommand.init()` so every command emits the warning automatically
- Adds a `_deprecationWarningPrinted` guard to make the method idempotent, preventing `service:*` commands (which still call it explicitly in `run()`) from double-printing
- Includes a changeset for a `patch` bump on the `apollo` package

## Test plan

- [x] Run any `client:*` command (e.g. `apollo client:check --help`) — deprecation warning should appear on stderr
- [x] Run any `service:*` command (e.g. `apollo service:check --help`) — deprecation warning should appear exactly once